### PR TITLE
ci: move to the thecluster runner scale set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: lang-runners
+    runs-on: thecluster
     container: ghcr.io/catthehacker/ubuntu:runner-latest
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"


### PR DESCRIPTION
The `lang-runners` scale set is being retired in [the-cluster](https://github.com/UnstoppableMango/the-cluster) along with the rest of `apps/arc-runners/compat-helm-release.yml`. The `arc-runner-scale-set` chart registers one scale set per repo, named `thecluster`, so `runs-on` moves to that label.

Merge before the-cluster drops the compat release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)